### PR TITLE
glcommon: install using `@loader_path` as its ID

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -40,6 +40,10 @@ set (common_protos
   Puncture.proto
 )
 
+if (APPLE AND NOT PARAVIEW_DO_UNIX_STYLE_INSTALL)
+  set(CMAKE_INSTALL_NAME_DIR "@loader_path/../Libraries")
+endif ()
+
 add_library (glcommon SHARED ${common_sources} ${common_proto_sources})
 target_include_directories(glcommon PUBLIC ${CMAKE_CURRENT_BINARY_DIR})
 


### PR DESCRIPTION
The library is not tied to the executable which is loading the plugins,
but to the plugins themselves. `@executable_path` is meant for libraries
that are known by and ship with the executable.